### PR TITLE
docs: add a description for the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc-plugin-custom-validation",
   "version": "0.0.0-development",
-  "description": "",
+  "description": "Require a description or tag on documentation members",
   "keywords": [
     "typedoc-plugin"
   ],


### PR DESCRIPTION
Without this, npm tries to guess a description, which ends up being `<div align="center">` as that is the first line in the readme.